### PR TITLE
#190 Move action helpers to knotx-commons

### DIFF
--- a/src/main/java/io/knotx/commons/time/TimeCalculator.java
+++ b/src/main/java/io/knotx/commons/time/TimeCalculator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * The code comes from https://github.com/tomaszmichalak/vertx-rx-map-reduce.
+ */
+package io.knotx.commons.time;
+
+import static java.time.Instant.now;
+
+public final class TimeCalculator {
+
+  private TimeCalculator() {
+    // Utility class
+  }
+
+  public static long millisFrom(long startTime) {
+    return now().toEpochMilli() - startTime;
+  }
+
+}

--- a/src/main/java/io/knotx/commons/validation/ValidationHelper.java
+++ b/src/main/java/io/knotx/commons/validation/ValidationHelper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.commons.validation;
+
+import java.util.function.Supplier;
+
+public final class ValidationHelper {
+
+  private ValidationHelper() {
+    // utility class
+  }
+
+  public static void checkArgument(boolean condition, Supplier<RuntimeException> exceptionSupplier) {
+    if (condition) {
+      throw exceptionSupplier.get();
+    }
+  }
+}


### PR DESCRIPTION
## Description
Moves `TimeCalculator` and `ValidationHelper` from [knotx-fragments](https://github.com/Knotx/knotx-fragments)

## Motivation and Context
Knotx/knotx-fragments#190

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
