### PR TITLE
Bring flatIfComposite helper method from knotx-fragments

### DIFF
--- a/src/main/java/io/knotx/commons/error/ExceptionUtils.java
+++ b/src/main/java/io/knotx/commons/error/ExceptionUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.commons.error;
+
+import io.reactivex.exceptions.CompositeException;
+import java.util.Collections;
+import java.util.List;
+
+public final class ExceptionUtils {
+
+  public static List<Throwable> flatIfComposite(Throwable error) {
+    if (error instanceof CompositeException) {
+      return ((CompositeException) error).getExceptions();
+    } else {
+      return Collections.singletonList(error);
+    }
+  }
+
+}

--- a/src/test/java/io/knotx/commons/error/ExceptionUtilsTest.java
+++ b/src/test/java/io/knotx/commons/error/ExceptionUtilsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.commons.error;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/io/knotx/commons/error/ExceptionUtilsTest.java
+++ b/src/test/java/io/knotx/commons/error/ExceptionUtilsTest.java
@@ -1,0 +1,36 @@
+package io.knotx.commons.error;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.reactivex.exceptions.CompositeException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ExceptionUtilsTest {
+
+  @Test
+  @DisplayName("Expect single exception when not composite")
+  void singleException() {
+    Throwable single = new RuntimeException();
+
+    List<Throwable> flattened = ExceptionUtils.flatIfComposite(single);
+
+    assertEquals(Collections.singletonList(single), flattened);
+  }
+
+  @Test
+  @DisplayName("Expect flattened composite exception")
+  void compositeException() {
+    Throwable first = new RuntimeException();
+    Throwable second = new IllegalStateException();
+    Throwable composite = new CompositeException(first, second);
+
+    List<Throwable> flattened = ExceptionUtils.flatIfComposite(composite);
+
+    assertEquals(Arrays.asList(first, second), flattened);
+  }
+
+}


### PR DESCRIPTION
## Description
Brings `flatIfComposite` helper method from `knotx-fragments` and provides unit test.

## Motivation and Context
Knotx/knotx-fragments#179

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
