### PR TITLE
Knotx/knotx-fragments#173 Helper for putting nested values in Json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-commons` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-37](https://github.com/Knotx/knotx-commons/pull/37) Updates in `JsonObjectUtil`.
 - [PR-35](https://github.com/Knotx/knotx-commons/pull/35) Introduce Cache and CacheFactory interfaces and in-memory implementation - moved from `knotx-fragments` [192](https://github.com/Knotx/knotx-fragments/issues/192)
                 
 ## 2.2.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(group = "io.vertx", name = "vertx-rx-java2")
 
     implementation(group = "com.google.guava", name = "guava")
+    implementation(group = "org.apache.commons", name = "commons-lang3")
     implementation(group = "org.junit.jupiter", name = "junit-jupiter-api")
     implementation(group = "org.junit.jupiter", name = "junit-jupiter-params")
     implementation(group = "org.junit.jupiter", name = "junit-jupiter-migrationsupport")

--- a/src/main/java/io/knotx/commons/json/JsonObjectUtil.java
+++ b/src/main/java/io/knotx/commons/json/JsonObjectUtil.java
@@ -15,48 +15,92 @@
  */
 package io.knotx.commons.json;
 
-import java.util.Optional;
-import java.util.function.Function;
+import static java.util.stream.Collectors.toList;
 
 import io.vertx.core.json.JsonObject;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import org.apache.commons.lang3.StringUtils;
 
-public class JsonObjectUtil {
+public final class JsonObjectUtil {
 
-  private static Function<JsonObject, JsonObject> toJsonObject(String key) {
-    return json -> json.getJsonObject(key);
+  private JsonObjectUtil() {
+    // utility class
   }
 
-  private static Function<JsonObject, String> toString(String key) {
-    return json -> Optional.ofNullable(json.getValue(key))
-        .map(Object::toString)
-        .orElse("");
-  }
-
-  public static String getString(String key, JsonObject parent) {
-    return getValue(key, parent, JsonObjectUtil::toString);
+  public static Object getObject(String key, JsonObject parent) {
+    return getValue(key, parent,
+        (lastSelector, directParent) -> directParent.getValue(lastSelector));
   }
 
   public static JsonObject getJsonObject(String key, JsonObject parent) {
     return getValue(key, parent, JsonObjectUtil::toJsonObject);
   }
 
-  public static <T> T getValue(String key, JsonObject parent,
-      Function<String, Function<JsonObject, T>> func) {
-    int dotIndex = key.indexOf('.');
-
-    if (dotIndex == -1) {
-      return func.apply(key)
-          .apply(parent);
-    }
-
-    String newKey = key.substring(dotIndex + 1);
-    JsonObject child = getChild(key, parent, dotIndex);
-
-    return child == null ? null : getValue(newKey, child, func);
+  public static String getString(String key, JsonObject parent) {
+    return getValue(key, parent, JsonObjectUtil::toString);
   }
 
-  private static JsonObject getChild(String key, JsonObject parent, int dotIndex) {
-    String childKey = key.substring(0, dotIndex);
-    return parent.getJsonObject(childKey);
+  public static void putValue(String key, JsonObject node, Object value) {
+    getOrPutJsonObject(node, allButLastSelector(key))
+        .put(lastSelector(key), value);
+  }
+
+  private static <T> T getValue(String key, JsonObject parent,
+      BiFunction<String, JsonObject, T> func) {
+    JsonObject directParent = getJsonObject(parent, allButLastSelector(key));
+
+    return func.apply(lastSelector(key), directParent);
+  }
+
+  private static List<String> allButLastSelector(String keyChain) {
+    String[] keys = StringUtils.split(keyChain, ".");
+    return Arrays.stream(keys)
+        .limit(keys.length - 1)
+        .collect(toList());
+  }
+
+  private static String lastSelector(String keyChain) {
+    return StringUtils.contains(keyChain, '.')
+        ? StringUtils.substringAfterLast(keyChain, ".")
+        : keyChain;
+  }
+
+  private static JsonObject getJsonObject(JsonObject node, List<String> keys) {
+    for (String key : keys) {
+      node = node.getJsonObject(key);
+      if (node == null) {
+        return new JsonObject();
+      }
+    }
+    return node;
+  }
+
+  private static JsonObject getOrPutJsonObject(JsonObject node, List<String> keys) {
+    for (String key : keys) {
+      node = getOrPutJsonObject(node, key);
+    }
+    return node;
+  }
+
+  private static JsonObject getOrPutJsonObject(JsonObject node, String key) {
+    JsonObject next = node.getJsonObject(key);
+    if (next == null) {
+      next = new JsonObject();
+      node.put(key, next);
+    }
+    return next;
+  }
+
+  private static JsonObject toJsonObject(String key, JsonObject parent) {
+    return parent.getJsonObject(key);
+  }
+
+  private static String toString(String key, JsonObject parent) {
+    return Optional.ofNullable(parent.getValue(key))
+        .map(Object::toString)
+        .orElse("");
   }
 }

--- a/src/main/java/io/knotx/commons/json/JsonObjectUtil.java
+++ b/src/main/java/io/knotx/commons/json/JsonObjectUtil.java
@@ -50,7 +50,7 @@ public final class JsonObjectUtil {
 
   private static <T> T getValue(String key, JsonObject parent,
       BiFunction<String, JsonObject, T> func) {
-    JsonObject directParent = getJsonObject(parent, allButLastSelector(key));
+    JsonObject directParent = getInnerJsonObject(parent, allButLastSelector(key));
 
     return func.apply(lastSelector(key), directParent);
   }
@@ -68,7 +68,7 @@ public final class JsonObjectUtil {
         : keyChain;
   }
 
-  private static JsonObject getJsonObject(JsonObject node, List<String> keys) {
+  private static JsonObject getInnerJsonObject(JsonObject node, List<String> keys) {
     for (String key : keys) {
       node = node.getJsonObject(key);
       if (node == null) {

--- a/src/test/java/io/knotx/commons/json/JsonObjectUtilTest.java
+++ b/src/test/java/io/knotx/commons/json/JsonObjectUtilTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.commons.json;
+
+import static io.knotx.commons.json.JsonObjectUtil.getJsonObject;
+import static io.knotx.commons.json.JsonObjectUtil.getObject;
+import static io.knotx.commons.json.JsonObjectUtil.getString;
+import static io.knotx.commons.json.JsonObjectUtil.putValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JsonObjectUtilTest {
+
+  private static final String KEY = "root.nested.value";
+
+  @Test
+  @DisplayName("Expect nested object to be returned")
+  void nestedLongReturned() {
+    long value = 1000L;
+
+    JsonObject object = objectWithValue(value);
+
+    assertEquals(value, getObject(KEY, object));
+  }
+
+  @Test
+  @DisplayName("Expect nested JsonObject to be returned")
+  void nestedJsonObjectReturned() {
+    JsonObject value = new JsonObject()
+        .put("some-key", "some-value");
+
+    JsonObject object = objectWithValue(value);
+
+    assertEquals(value, getJsonObject(KEY, object));
+  }
+
+  @Test
+  @DisplayName("Expect nested JsonObject to be returned")
+  void nestedStringReturned() {
+    String value = "some-string";
+
+    JsonObject object = objectWithValue(value);
+
+    assertEquals(value, getString(KEY, object));
+  }
+
+  @Test
+  @DisplayName("Expect null when object does not exist")
+  void objectDoesNotExist() {
+    assertNull(getObject(KEY, new JsonObject()));
+  }
+
+  @Test
+  @DisplayName("Expect empty string when string does not exist")
+  void stringDoesNotExist() {
+    assertEquals("", getString(KEY, new JsonObject()));
+  }
+
+  @Test
+  @DisplayName("Expect null when JsonObject does not exist")
+  void jsonObjectDoesNotExist() {
+    assertNull(getJsonObject(KEY, new JsonObject()));
+  }
+
+  @Test
+  @DisplayName("Expect nested value to be replaced")
+  void nestedValueReplaced() {
+    JsonObject object = objectWithValue(1000L);
+
+    putValue(KEY, object, 2000L);
+
+    assertEquals(2000L, object.getJsonObject("root").getJsonObject("nested").getValue("value"));
+  }
+
+  @Test
+  @DisplayName("Expect nested JsonObjects to be created and value placed")
+  void nestedStructureCreated() {
+    JsonObject object = new JsonObject();
+
+    putValue(KEY, object, 1000L);
+
+    assertEquals(1000L, object.getJsonObject("root").getJsonObject("nested").getValue("value"));
+  }
+
+  private JsonObject objectWithValue(Object value) {
+    return new JsonObject()
+        .put("root", new JsonObject()
+            .put("nested", new JsonObject()
+                .put("value", value)));
+  }
+
+}


### PR DESCRIPTION
## Description
Provides helper method to put a nested value in `JsonObject`. 
Refactors existing methods in `JsonObjectUtil` and provides unit tests.

ℹ️ Contract for `getString` changes: the function no longer returns null if some intermediate key is not present, but returns an empty JsonObject instead. Validated it does not change `PlaceholdersResolver` behaviour (the only usage in stack)

## Motivation and Context
Knotx/knotx-fragments#173

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
